### PR TITLE
IGNITE-18991 Remove zoneId field from RebalanceRaftGroupEventsListener

### DIFF
--- a/modules/distribution-zones/src/main/java/org/apache/ignite/internal/distributionzones/rebalance/RebalanceRaftGroupEventsListener.java
+++ b/modules/distribution-zones/src/main/java/org/apache/ignite/internal/distributionzones/rebalance/RebalanceRaftGroupEventsListener.java
@@ -132,10 +132,6 @@ public class RebalanceRaftGroupEventsListener implements RaftGroupEventsListener
     /** Executor for scheduling rebalance retries. */
     private final ScheduledExecutorService rebalanceScheduler;
 
-    /** Zone id. */
-    // TODO: remove this
-    private final int zoneId;
-
     /** Performs reconfiguration of a Raft group of a partition. */
     private final PartitionMover partitionMover;
 
@@ -157,7 +153,6 @@ public class RebalanceRaftGroupEventsListener implements RaftGroupEventsListener
             IgniteSpinBusyLock busyLock,
             PartitionMover partitionMover,
             ScheduledExecutorService rebalanceScheduler,
-            int zoneId,
             int tableId
     ) {
         this.metaStorageMgr = metaStorageMgr;
@@ -165,7 +160,6 @@ public class RebalanceRaftGroupEventsListener implements RaftGroupEventsListener
         this.busyLock = busyLock;
         this.partitionMover = partitionMover;
         this.rebalanceScheduler = rebalanceScheduler;
-        this.zoneId = zoneId;
         this.tableId = tableId;
     }
 
@@ -258,7 +252,7 @@ public class RebalanceRaftGroupEventsListener implements RaftGroupEventsListener
         try {
             int partId = zonePartitionId.partitionId();
 
-            Entry counterEntry = metaStorageMgr.get(tablesCounterKey(zoneId, partId)).get();
+            Entry counterEntry = metaStorageMgr.get(tablesCounterKey(zonePartitionId)).get();
 
             assert counterEntry.value() != null;
 
@@ -272,7 +266,7 @@ public class RebalanceRaftGroupEventsListener implements RaftGroupEventsListener
                 return;
             }
 
-            Condition condition = value(tablesCounterKey(zoneId, partId)).eq(counterEntry.value());
+            Condition condition = value(tablesCounterKey(zonePartitionId)).eq(counterEntry.value());
 
             byte[] stableArray = Assignments.toBytes(stable);
 
@@ -283,7 +277,7 @@ public class RebalanceRaftGroupEventsListener implements RaftGroupEventsListener
             }
 
             Update successCase = ops(
-                    put(tablesCounterKey(zoneId, partId), toBytes(counter)),
+                    put(tablesCounterKey(zonePartitionId), toBytes(counter)),
                     // Todo: change to one key https://issues.apache.org/jira/browse/IGNITE-18991
                     put(raftConfigurationAppliedKey(zonePartitionId), stableArray)
             ).yield(TABLES_COUNTER_DECREMENT_SUCCESS);
@@ -292,6 +286,7 @@ public class RebalanceRaftGroupEventsListener implements RaftGroupEventsListener
 
             int res = metaStorageMgr.invoke(iif(condition, successCase, failCase)).get().getAsInt();
 
+            int zoneId = zonePartitionId.zoneId();
             if (res < 0) {
                 LOG.info("Count down of zone's tables counter is failed. "
                                 + "Going to retry [zoneId={}, appliedPeers={}]",


### PR DESCRIPTION
A small fix corresponding to the [note](https://github.com/apache/ignite-3/pull/3422#discussion_r1560040483) in [original PR's `IGNITE-18991 Move stable/planned/pending assignments from table to distribution zone root keys` discussion](https://github.com/apache/ignite-3/pull/3422)

1. `zoneId` field is removed from `RebalanceRaftGroupEventsListener`:
  - in 3 `tablesCounterKey` callings `zonePartitionId` is passed;
  - in 2 logging lines pass local `zoneId` var from `zonePartitionId.zoneId()`.
2. In `RebalanceUtils` are numerous changes like:
  - `partId` to `zonePartiotionId` changes in args and javadocs;
  - javadoc of `zonePartiotionId` args are changed to corresponding meaning;
  - `tablesCounterKey` overloading with `ZonePartitionId` arg for point 1 fix with `zoneId` removing.